### PR TITLE
Temporarily remove Swift-DocC Plugin

### DIFF
--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -27,10 +27,3 @@ let package = Package(
             dependencies: ["SymbolKit"]),
     ]
 )
-
-// SwiftPM command plugins are only supported by Swift version 5.6 and later.
-#if swift(>=5.6)
-package.dependencies += [
-    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-]
-#endif

--- a/bin/update-gh-pages-documentation-site
+++ b/bin/update-gh-pages-documentation-site
@@ -24,9 +24,32 @@ filepath() {
 }
 
 SWIFT_DOCC_SYMBOLKIT_ROOT="$(dirname $(dirname $(filepath $0)))"
+SYMBOL_GRAPH_OUTPUT_DIR="$SWIFT_DOCC_SYMBOLKIT_ROOT/.build/swift-docc/symbol-graphs"
+
+mkdir -p "$SYMBOL_GRAPH_OUTPUT_DIR"
+rm -f "$SYMBOL_GRAPH_OUTPUT_DIR/*.*"
 
 # Set current directory to the repository root
 cd "$SWIFT_DOCC_SYMBOLKIT_ROOT"
+
+# On non-Darwin systems we expect the 'docc' command-line tool to be in the current path.
+# On Darwin, we expect 'docc' to be available via Xcode's 'xcrun'.
+DOCC_CMD=""
+if command -v xcrun &> /dev/null
+then
+    DOCC_CMD="xcrun docc"
+elif command -v docc &> /dev/null
+then
+    DOCC_CMD="docc"
+else
+    echo "Failed to find 'docc' or 'xcrun' in the current path."
+    exit 1
+fi
+
+# Generate symbol graph files for SymbolKit
+swift build --target SymbolKit \
+  -Xswiftc -emit-symbol-graph \
+  -Xswiftc -emit-symbol-graph-dir -Xswiftc "$SYMBOL_GRAPH_OUTPUT_DIR"
 
 # Use git worktree to checkout the gh-pages branch of this repository in a gh-pages sub-directory
 git fetch
@@ -37,13 +60,13 @@ export DOCC_JSON_PRETTYPRINT="YES"
 
 # Generate documentation for the 'SymbolKit' target and output it
 # to the /docs subdirectory in the gh-pages worktree directory.
-swift package \
-    --allow-writing-to-directory "$SWIFT_DOCC_SYMBOLKIT_ROOT/gh-pages/docs" \
-    generate-documentation \
-    --target SymbolKit \
-    --disable-indexing \
+$DOCC_CMD convert "$SWIFT_DOCC_SYMBOLKIT_ROOT/Sources/SymbolKit/SymbolKit.docc" \
+    --fallback-display-name SymbolKit \
+    --fallback-bundle-identifier org.swift.SymbolKit \
+    --fallback-bundle-version 1.0.0 \
     --transform-for-static-hosting \
     --hosting-base-path swift-docc-symbolkit \
+    --additional-symbol-graph-dir "$SYMBOL_GRAPH_OUTPUT_DIR" \
     --output-path "$SWIFT_DOCC_SYMBOLKIT_ROOT/gh-pages/docs"
 
 # Save the current commit we've just built documentation from in a variable


### PR DESCRIPTION
Temporarily removes the Swift-DocC Plugin since we have a depenency cycle issue.